### PR TITLE
Fix MissingTemplate error after Rails 8 upgrade

### DIFF
--- a/lib/simple_json/simple_json_renderable.rb
+++ b/lib/simple_json/simple_json_renderable.rb
@@ -29,7 +29,7 @@ module SimpleJson
       # use super when any of [:body, :plain, :html] exist in options
       return super if self.class::RENDER_FORMATS_IN_PRIORITY.any? { |key| options.key? key }
 
-      template_name = template_name(options[:template] || action_name)
+      template_name = template_name(options[:template] || options[:action] || action_name)
       if options.key?(:json)
         process_options(options)
         @rendered_format = 'application/json; charset=utf-8'

--- a/test/dummy_app/app/controllers/api/posts_controller.rb
+++ b/test/dummy_app/app/controllers/api/posts_controller.rb
@@ -8,6 +8,12 @@ if Rails::VERSION::MAJOR >= 5
       def show(id)
         @post = Post.find id
       end
+
+      def renamed_show(id)
+        @post = Post.find id
+
+        render :show
+      end
     end
   end
 end

--- a/test/dummy_app/config/routes.rb
+++ b/test/dummy_app/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   if Rails::VERSION::MAJOR >= 5
     namespace :api do
       resources :posts, only: :show
+      get '/renamed_posts/:id', to: 'posts#renamed_show'
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/test/features/action_controller_api_test.rb
+++ b/test/features/action_controller_api_test.rb
@@ -12,6 +12,14 @@ if Rails::VERSION::MAJOR >= 5
 
       assert_equal json, { 'title' => 'post 1' }
     end
+
+    test 'The renamed template correctly renders a JSON' do
+      get '/api/renamed_posts/1.json'
+
+      json = response.parsed_body
+
+      assert_equal json, { 'title' => 'post 1' }
+    end
   end
 
 end


### PR DESCRIPTION
Before this update, SimpleJson expected to generate the template_name in `options[:template]`. However, with the Rails 8 upgrade (ref: https://github.com/rails/rails/pull/52984), a value is no longer passed to `options[:template]`. 
For example:
```
Error: test: The renamed template correctly renders a JSON(ActionControllerAPITest):
  ActionView::MissingTemplate: Missing template api/posts/show with {:locale=>[:en], :formats=>[:json], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jb, :jbuilder]}.
```
Therefore, I modified it to generate the template_name from `options[:action]`.